### PR TITLE
Add Morrisons Now picker quick start guide to online dashboard

### DIFF
--- a/online.html
+++ b/online.html
@@ -73,6 +73,89 @@
       </details>
     </section>
 
+    <section id="morrisons-now-quick-start">
+      <details class="quick-guide-collapsible" open>
+        <summary>
+          <span class="summary-title">🟢 Morrisons Now – Picker Quick Start Guide</span>
+          <i class="fas fa-chevron-down summary-icon" aria-hidden="true"></i>
+        </summary>
+        <div class="quick-guide-content">
+          <ol class="quick-guide-list">
+            <li>
+              <strong>Be Ready Before Picking</strong>
+              <ul>
+                <li>Charged HHT (picking device) and finger scanner</li>
+                <li>Trolley (immediacy/store pick trolley)</li>
+                <li>Morrisons Now bags (order via Bunzl code: <strong>CAR95014</strong>)</li>
+                <li>Barcode stickers (order via Bunzl code: <strong>LBL95875</strong>)</li>
+                <li>Collection/staging area clean, signed, and under CCTV</li>
+              </ul>
+            </li>
+            <li>
+              <strong>Identifying Morrisons Now Orders</strong>
+              <ul>
+                <li>In OSP (Store Ops dashboard) select <em>Single Order Pick</em>, not multi.</li>
+                <li>Orders show <strong>EXD_external_delivery</strong> instead of a route number.</li>
+              </ul>
+            </li>
+            <li>
+              <strong>Starting a Pick</strong>
+              <ul>
+                <li>On HHT choose <em>ISF</em> tile &rarr; <em>Single Order Pick</em>.</li>
+                <li>Scan trolley barcode and review the number of bags required.</li>
+                <li>Label each bag with barcode stickers and scan every bag.</li>
+                <li>Press <strong>Start Pick</strong>.</li>
+              </ul>
+            </li>
+            <li>
+              <strong>Picking Rules</strong>
+              <ul>
+                <li>Follow the pick path shown on the device.</li>
+                <li>Maintain chill chain &le; 30 minutes for fresh/frozen products.</li>
+                <li>Pick best date codes (3+ days); avoid reduced or damaged stock.</li>
+                <li>Pack heavy items at the bottom; raw/chemicals in an extra online bag.</li>
+                <li>Scan the product, then scan the bag barcode.</li>
+              </ul>
+            </li>
+            <li>
+              <strong>Finishing the Pick</strong>
+              <ul>
+                <li>Review the summary screen and press <strong>Done</strong>.</li>
+                <li>Proceed to buffering: scan each bag, then the buffer rack location.</li>
+                <li>Ensure bags are staged for courier collection.</li>
+              </ul>
+            </li>
+            <li>
+              <strong>Dispatching</strong>
+              <ul>
+                <li>Approve for Dispatch on the HHT or desktop so a courier is assigned.</li>
+                <li>Write the last four digits of the order number on each bag (e.g., “1234 – 1 of 2”).</li>
+                <li>Seal bags (tamper proof) and place on the Morrisons Now rack.</li>
+              </ul>
+            </li>
+            <li>
+              <strong>Collection</strong>
+              <ul>
+                <li>Courier identifies the order by the last four digits written on the bags.</li>
+                <li>Couriers must take the full order—no partial handovers.</li>
+              </ul>
+            </li>
+            <li>
+              <strong>If Something Goes Wrong</strong>
+              <ul>
+                <li>Out of stock? Use the normal substitutions process.</li>
+                <li>Order not collected/delivered in 90 mins? Mark as failed delivery in External Delivery dashboard and waste/return stock as needed.</li>
+                <li>Order returned to store? Follow the standard Online returns/waste process.</li>
+              </ul>
+            </li>
+          </ol>
+          <p>
+            <strong>Key reminders:</strong> Minimum order value £15 | Maximum 30 items | Delivery aim within 60 mins (90 mins max) | Customers cannot reject subs at the door (refund only) | Keep the staging area monitored by CCTV.
+          </p>
+        </div>
+      </details>
+    </section>
+
     <section id="partner-platforms">
       <h2><i class="fas fa-store"></i> Partner Platform Management</h2>
       <div class="dashboard">


### PR DESCRIPTION
## Summary
- add a dedicated Morrisons Now picker quick start guide to the online operations page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e21b011c348321a08f0a6f9ab79b8b